### PR TITLE
Specified 80 port for ubuntu keyserver

### DIFF
--- a/wiki/Tutorials/RStudio_Server/index.md
+++ b/wiki/Tutorials/RStudio_Server/index.md
@@ -38,7 +38,7 @@ echo -e "deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/ \n" | s
 Now we add the GPG key from R CRAN repository to allow downloading from the R repository
 
 ```
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E084DAB9
 ```
 
 It’s time to update your software repositories to get the latest R version


### PR DESCRIPTION
With default instance configuration it is impossible to access ubuntu keyserver as it uses some non typical port. Instead of opening new ports one can just specify 80 port explicitly. I think it can save troubles for many users.