### PR TITLE
Fixing incorrect SSH commands (minus character incorrect)

### DIFF
--- a/wiki/quickstart.md
+++ b/wiki/quickstart.md
@@ -72,7 +72,7 @@ Note that on your "User information" page only OpenSSH public keys are accepted 
 On all UNIX based operating systems ‘keygen’ may be used to create a key pair. A Linux command example is given below:
 
 ~~~BASH
-$ ssh-keygen –t rsa -f new_id
+$ ssh-keygen -t rsa -f new_id
 ~~~
 
 which will produce the files new_id and new_id.pub.
@@ -325,13 +325,13 @@ For Linux and MacOS just use ssh, specifying the correct IP, the right key and t
 It can be found within the Horizon dashboard under Instances. An example of a Linux command is given below:
 
 ~~~BASH
-ssh –i /path/to/private/key @
+ssh -i /path/to/private/key @
 ~~~
 
 An example for a CentOS machine with the floating IP 1.2.3.4 would be:
 
 ~~~BASH
-ssh –i /path/to/private/key ubuntu@1.2.3.4
+ssh -i /path/to/private/key ubuntu@1.2.3.4
 ~~~
 
 If you need X-Forwarding for graphical user interfaces don’t forget to set the –X flag and check if the xauth package is installed on the host and the server and the X-Forwarding settings are correct. 


### PR DESCRIPTION
This is a tricky one: The given SSH commands do not work on copy paste, because the minus character are not really minus characters. This results in errors of the type
```
ssh –i denbi ubuntu@134.176.27.178
ssh: Could not resolve hostname \342\200\223i: Name or service not known
```
This fixes the issue, see https://tumblr.gudge.com/post/18186353550/ssh-could-not-resolve-hostname-342200223i