### PR TITLE
fix(pdf-plugin): remove pdf pulgin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,6 @@ Use the Environment which will also be used in production.
 docker run -it -v "$(pwd)/wiki:/srv_root/docs/wiki" -v "$(pwd)/config.yml:/config.yml" -p "8000:8000"  --entrypoint="mkdocs" denbicloud/mkdocswebhook:2.1.0 serve -f /config.yml --dev-addr 0.0.0.0:8000
 ~~~
 
-#### generate PDF
-
-If you want to generate a PDF you have to set the environment variable `ENABLE_PDF_EXPORT` to 1.
-In docker it would be the above command with the environment variable `-e ENABLE_PDF_EXPORT=1`
-
 ### Local
 
 Please install the libraries used in the production instance:

--- a/config.yml
+++ b/config.yml
@@ -13,8 +13,6 @@ repo_url: 'https://github.com/deNBI/cloud-user-docs'
 edit_uri: blob/master/wiki/
 plugins:
  - search
- - pdf-export:
-     enabled_if_env: ENABLE_PDF_EXPORT
 markdown_extensions:
   - admonition
   - codehilite


### PR DESCRIPTION
@dweinholz 
Remove pdf-export requiroments, now incompatible with older webhook builds. Test with corresponding PR in webhook repo

https://github.com/deNBI/mkdocsWebhook/pull/25

Try to fulfill the following points before the Pull Request is merged:

- [ ] Please WAIT for the tests to finish.
- [ ] All tests have been successfully completed.

