### PR TITLE
feat(SimpleVM): Reference to new wiki

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,9 +30,11 @@ repo_url: 'https://github.com/deNBI/cloud-user-docs'
 edit_uri: blob/master/wiki/
 use_directory_urls: true
 site_url: !ENV [SITE_URL, 'https://cloud.denbi.de/wiki/']
+
 plugins:
   - search
   - glightbox
+  - macros
   - git-revision-date-localized:
         fallback_to_build_date: true
   - htmlproofer:
@@ -101,7 +103,8 @@ extra:
       name: de.NBI on YouTube
     - icon: fontawesome/brands/wikipedia-w
       link: https://en.wikipedia.org/wiki/German_Network_for_Bioinformatics_Infrastructure
-      name: de.NBI on Wikipedia
+      name: de.NBI on Wikipedia  
+  simplevm_wiki_link: !ENV [SIMPLE_VM_WIKI_LINK, 'https://simplevm.denbi.de/wiki/']
 
 nav:
   - 'Home' : index.md

--- a/wiki/simple_vm/index.md
+++ b/wiki/simple_vm/index.md
@@ -1,47 +1,8 @@
 # SimpleVM
 
-Start and manage virtual machines with ease and let SimpleVM take care of various settings for you.
+The SimpleVM functions are gradually being moved to a dedicated platform to provide a better user experience. 
 
-`Easy setup`
-:    SimpleVM runs in a pre-configured network setup. You don't have to set up anything, start your VM with just some 
-clicks. Afterward, you only need to install the tools you need to work on your project.
-Even then, SimpleVM might already offer to do it for you.
-See [New instance](new_instance.md) for more details.
+Accordingly, a separate wiki is now available for this type of project, which is constantly being adapted.
 
-`SSH access`
-:    SimpleVM configures the SSH access for you and provides you with all appropriate commands for SSH access.
-See [Keypairs](keypairs.md) for more details.
+The new wiki can be found at the following link: [{{extra.simplevm_wiki_link}}]({{extra.simplevm_wiki_link}})
 
-`Browser-based access`
-:    SimpleVM can configure browser-based access to your VM based on your chosen research environment, like
-RStudio, Apache Guacamole or VSCode.<br>
-It further provides you with a custom URL. 
-See [Research environments](customization.md#research-environments) for more details.
-
-`Tools and environment setup`
-:    SimpleVM can set up a Conda environment and install tools of your choosing from various Conda channels.
-See [Conda](customization.md#conda) for more details.
-
-`Volume management`
-:    Manage your volumes with SimpleVM. Create, attach and mount them to your virtual machines.
-See [Volumes](volumes.md) for more details.
-
-`Snapshot management`
-:    Manage vm snapshots with SimpleVM. Create a snapshot of a virtual machine and
-start new virtual machines with that snapshot, saving time by not having to configure machines with the same settings.
-See [Images and Snapshots](snapshots.md) for more details.
-
-`Cluster management`
-:    Manage clusters with SimpleVM. Create a cluster, remove, and add nodes.
-See [Cluster](Cluster/index.md) for more details.
-
-`Machine management`
-:    Manage your virtual machines with SimpleVM. You can stop, reboot, manage volume attachments, 
-and delete your vms on one page.
-See [Instance overview](instance_overview.md) for more details.
-
-`Workshop management`
-:    Manage your workshops with SimpleVM. You can create workshops, 
-add users and administrators, start virtual machines for all users, and email them information about
-their personal virtual machine.
-See [Workshop](workshop.md) for more details.


### PR DESCRIPTION
@dweinholz 

When trying to test, you need the latest [mkdocs-webhook version](https://github.com/deNBI/mkdocsWebhook/releases/tag/3.1.0), as we now use the [macros-plugin](https://mkdocs-macros-plugin.readthedocs.io/en/latest/)

needs `SIMPLEVM_WIKI_LINK` environment-variable, which will set the link on the page referencing to the new wiki
defaults to https://simplevm.denbi.de/wiki/

Portal-PR: https://github.com/deNBI/cloud-portal/pull/2246

Try to fulfill the following points before the Pull Request is merged:
- [ ] Please create your prs against the dev branch
- [ ] Please WAIT for the tests to finish.
- [ ] All tests have been successfully completed.
- [ ] When adding a new documentation or tutorial, make sure that the markdown is linked in the config.yml
